### PR TITLE
Merge upstream changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 ---
 
+Requires dbt >= 0.12.2
+
 This package provides out-of-the-box functionality to log events for all dbt invocations, including run start, run end, model start, and model end. It outputs all data and models to schema `[target.schema]_meta`. There are three convenience models to make it easier to parse the event log data.
 
 ### Setup

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
-  - git: "https://github.com/fishtown-analytics/dbt-utils.git"
-    revision: 0.1.12
+ - package: fishtown-analytics/dbt_utils
+   version: '>=0.1.20'


### PR DESCRIPTION
This PR merges changes from the upstream repo (fishtown-analytics/dbt-event-logging).
Importantly, it uses the `package:` syntax, which means we can use the latest version of the Segment package without conflicts between dbt-utils versions.