### PR TITLE
Use custom schemas for audit table

### DIFF
--- a/macros/audit.sql
+++ b/macros/audit.sql
@@ -1,11 +1,20 @@
 {% macro get_audit_relation() %}
+
+    {#-
+    A project's version of the generate_schema_name macro will take precedence
+    over the global version
+    -#}
+    {%- set audit_schema=generate_schema_name('dbt_meta') -%}
+
     {%- set audit_table =
         api.Relation.create(
             identifier='dbt_audit_log',
-            schema='dbt_meta',
+            schema=audit_schema,
             type='table'
         ) -%}
+
     {{ return(audit_table) }}
+
 {% endmacro %}
 
 


### PR DESCRIPTION
This undoes some of Michael's work in PR #2 – now that prod, qa and dev are all being run within one cluster, using the same table often leads to longer dbt run times as queries get stuck trying to write to the same table.

The package still diverges slightly from Fishtown's version, so a forked version will have to be maintained.

As a note, we have an outstanding issue on the main repo to change the way the custom schemas work (see [here](https://github.com/fishtown-analytics/dbt-event-logging/issues/7)), when I get around to that we might be able to use the main package instead of maintaining a forked version.